### PR TITLE
Create a basic Astro site for a curriculum web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./astro-site
+
+      - name: Build Astro site
+        run: npm run build
+        working-directory: ./astro-site
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./astro-site/dist

--- a/astro-site/astro.config.mjs
+++ b/astro-site/astro.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://<your-github-username>.github.io/<your-repo-name>/',
+  base: '/<your-repo-name>/',
+  output: 'static',
+  integrations: [],
+});

--- a/astro-site/package.json
+++ b/astro-site/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "astro-site",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "start": "astro dev"
+  },
+  "dependencies": {
+    "astro": "^2.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/astro-site/src/pages/index.astro
+++ b/astro-site/src/pages/index.astro
@@ -1,0 +1,69 @@
+---
+title: "Curriculum Vitae - Kotlin Android Compose Developer"
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title}</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <header>
+    <h1>Curriculum Vitae</h1>
+    <h2>Kotlin Android Compose Developer</h2>
+  </header>
+  <main>
+    <section>
+      <h3>About Me</h3>
+      <p>Passionate Kotlin Android Compose developer with experience in building modern, responsive, and user-friendly mobile applications.</p>
+    </section>
+    <section>
+      <h3>Skills</h3>
+      <ul>
+        <li>Kotlin</li>
+        <li>Android Development</li>
+        <li>Jetpack Compose</li>
+        <li>MVVM Architecture</li>
+        <li>RESTful APIs</li>
+        <li>Git</li>
+        <li>Agile Methodologies</li>
+      </ul>
+    </section>
+    <section>
+      <h3>Experience</h3>
+      <ul>
+        <li>
+          <h4>Senior Android Developer</h4>
+          <p>Company XYZ, 2020 - Present</p>
+          <p>Developed and maintained Android applications using Kotlin and Jetpack Compose. Collaborated with cross-functional teams to define, design, and ship new features.</p>
+        </li>
+        <li>
+          <h4>Android Developer</h4>
+          <p>Company ABC, 2018 - 2020</p>
+          <p>Worked on various Android projects, implementing new features and fixing bugs. Gained experience in using Kotlin and Jetpack Compose for building modern Android applications.</p>
+        </li>
+      </ul>
+    </section>
+    <section>
+      <h3>Education</h3>
+      <ul>
+        <li>
+          <h4>Bachelor of Science in Computer Science</h4>
+          <p>University of Technology, 2014 - 2018</p>
+        </li>
+      </ul>
+    </section>
+    <section>
+      <h3>Contact</h3>
+      <p>Email: developer@example.com</p>
+      <p>LinkedIn: <a href="https://www.linkedin.com/in/developer">linkedin.com/in/developer</a></p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2023 Kotlin Android Compose Developer</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Add a basic Astro site for a Kotlin Android Compose developer's curriculum and configure GitHub Pages deployment.

* **Astro Site Setup**
  - Create `astro-site/package.json` with necessary dependencies and scripts for Astro.
  - Add `astro-site/astro.config.mjs` with basic configuration settings for the Astro site.
  - Create `astro-site/src/pages/index.astro` with content about the Kotlin Android Compose developer's curriculum.

* **GitHub Pages Deployment**
  - Add `.github/workflows/deploy.yml` to configure GitHub Actions for deploying the site to GitHub Pages.

