### PR TITLE
Fix title not found error during build

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ title: "Curriculum Vitae - Kotlin Android Compose Developer"
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{title}</title>
+  <title>{Astro.props.title}</title>
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>


### PR DESCRIPTION
Update the title variable in `src/pages/index.astro` to be passed correctly to the HTML `<title>` tag.

* Replace `{title}` with `{Astro.props.title}` in the HTML `<title>` tag

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nourthe/web/pull/5?shareId=7db4d305-6685-4a1b-a79d-09d905936dae).