### PR TITLE
Add astro tailwind styles to look better

### DIFF
--- a/.astro/data-store.json
+++ b/.astro/data-store.json
@@ -1,0 +1,1 @@
+[["Map",1,2],"meta::meta",["Map",3,4],"astro-version","5.0.7"]

--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1735416874898
+	}
+}

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,19 +10,19 @@ title: "Nahuel Ourthe - Android Engineer"
   <title>{Astro.props.title}</title>
   <link rel="stylesheet" href="/src/styles/tailwind.css">
 </head>
-<body>
-  <header>
-    <h1>Nahuel Ourthe</h1>
-    <h2>Android Engineer at Brubank</h2>
+<body class="bg-gray-100 text-gray-900 font-sans">
+  <header class="bg-primary text-white p-4 shadow-md3">
+    <h1 class="text-3xl font-bold">Nahuel Ourthe</h1>
+    <h2 class="text-xl">Android Engineer at Brubank</h2>
   </header>
-  <main>
-    <section>
-      <h3>About Me</h3>
+  <main class="p-4">
+    <section class="mb-8">
+      <h3 class="text-2xl font-semibold mb-2">About Me</h3>
       <p>I'm Nahuel Ourthe from Córdoba, Argentina, working at Brubank as an Android engineer.</p>
     </section>
-    <section>
-      <h3>Skills</h3>
-      <ul>
+    <section class="mb-8">
+      <h3 class="text-2xl font-semibold mb-2">Skills</h3>
+      <ul class="list-disc list-inside">
         <li>Kotlin</li>
         <li>Android Development</li>
         <li>Jetpack Compose</li>
@@ -32,37 +32,37 @@ title: "Nahuel Ourthe - Android Engineer"
         <li>Agile Methodologies</li>
       </ul>
     </section>
-    <section>
-      <h3>Experience</h3>
-      <ul>
-        <li>
-          <h4>Senior Android Developer</h4>
+    <section class="mb-8">
+      <h3 class="text-2xl font-semibold mb-2">Experience</h3>
+      <ul class="space-y-4">
+        <li class="bg-white p-4 rounded-md3 shadow-md3">
+          <h4 class="text-xl font-semibold">Senior Android Developer</h4>
           <p>Company XYZ, 2020 - Present</p>
           <p>Developed and maintained Android applications using Kotlin and Jetpack Compose. Collaborated with cross-functional teams to define, design, and ship new features.</p>
         </li>
-        <li>
-          <h4>Android Developer</h4>
+        <li class="bg-white p-4 rounded-md3 shadow-md3">
+          <h4 class="text-xl font-semibold">Android Developer</h4>
           <p>Company ABC, 2018 - 2020</p>
           <p>Worked on various Android projects, implementing new features and fixing bugs. Gained experience in using Kotlin and Jetpack Compose for building modern Android applications.</p>
         </li>
       </ul>
     </section>
-    <section>
-      <h3>Education</h3>
-      <ul>
-        <li>
-          <h4>Bachelor of Science in Computer Science</h4>
+    <section class="mb-8">
+      <h3 class="text-2xl font-semibold mb-2">Education</h3>
+      <ul class="space-y-4">
+        <li class="bg-white p-4 rounded-md3 shadow-md3">
+          <h4 class="text-xl font-semibold">Bachelor of Science in Computer Science</h4>
           <p>University of Technology, 2014 - 2018</p>
         </li>
       </ul>
     </section>
-    <section>
-      <h3>Contact</h3>
+    <section class="mb-8">
+      <h3 class="text-2xl font-semibold mb-2">Contact</h3>
       <p>Email: developer@example.com</p>
-      <p>LinkedIn: <a href="https://www.linkedin.com/in/developer">linkedin.com/in/developer</a></p>
+      <p>LinkedIn: <a href="https://www.linkedin.com/in/developer" class="text-primary">linkedin.com/in/developer</a></p>
     </section>
   </main>
-  <footer>
+  <footer class="bg-primary text-white p-4 text-center">
     <p>&copy; 2023 Kotlin Android Compose Developer</p>
   </footer>
 </body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,20 @@ module.exports = {
     './src/**/*.{astro,html,js,jsx,ts,tsx,vue}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: '#3ddc84', // Android green
+      },
+      fontFamily: {
+        sans: ['Roboto', 'sans-serif'],
+      },
+      borderRadius: {
+        'md3': '12px',
+      },
+      boxShadow: {
+        'md3': '0 4px 6px rgba(0, 0, 0, 0.1)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Add minimalistic style similar to Material 3 and set android green as the primary color.

* **Tailwind Configuration**: Extend the theme in `tailwind.config.js` to include android green as the primary color, add Roboto as the sans-serif font, and define custom border radius and box shadow for Material 3 style.
* **Index Page Styling**: Update `src/pages/index.astro` to apply Tailwind classes for a minimalistic style. Use android green as the primary color for the header and footer, and apply Material 3 styles to various sections.
* **Astro Configuration**: Remove unnecessary reference in `.astro/types.d.ts` and add `.astro/data-store.json` and `.astro/settings.json` for configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nourthe/web/pull/9?shareId=ed98a1d8-4e88-4107-b231-4d699bdf76e7).